### PR TITLE
Add support for quick consistency checking

### DIFF
--- a/Analyze/Maintainers.py
+++ b/Analyze/Maintainers.py
@@ -23,12 +23,182 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Short description:
 '''
-from fnmatch import fnmatch
+import glob
 import re
 import os
 from Utils import logger
 from Analyze import EnvParser
 import codecs
+
+
+class Rule(object):
+    """
+    A rule consists of a path and a rule type (include/exclude),
+    and a reference to the maintainer_entry that the rule belongs to
+    """
+    def __init__(self, path, maintainer_entry, rule_type):
+        if path.startswith('/'):
+            path = path[1:]
+        if path.endswith('/'):
+            path = path[:-1]
+
+        # This variable is only used during initialization, to put the rule in the right RuleTreeNode
+        self.path_components = path.split('/')
+
+        self.maintainer_entry = maintainer_entry
+        self.include = rule_type == 'include'
+        self.exclude = rule_type == 'exclude'
+        assert self.include or self.exclude
+
+
+class RuleTreeNode(object):
+    """
+    A node in a tree that represents the set of rules in a maintainer file.
+    Each node corresponds to a file or a directory in the file system,
+    and contains a list of the Rule objects that explicitly refers to this path
+    """
+
+    def __init__(self, name, parent, children):
+        self.name = name
+        self.parent = parent
+        self.children = children
+
+        # The rules that explicitly refers to this node.
+        self.rules = []
+
+    def insert(self, rule, path_components=None):
+        """
+        Inserts a rule in the right place in the tree, creating new nodes as necessary.
+        """
+
+        if path_components is None:
+            path_components = rule.path_components
+
+        if len(path_components) == 0:
+            self.rules.append(rule)
+            return
+        first = path_components[0]
+        for child in self.children:
+            if child.name == first:
+                child.insert(rule, path_components[1:])
+                return
+        new_child = RuleTreeNode(first, self, [])
+        new_child.insert(rule, path_components[1:])
+        self.children.append(new_child)
+
+    def find_best_match(self, path_components):
+        """
+        Takes a list of path components (e.g. ['usr', 'bin', 'env']), and returns the best matching node
+        (i.e. the one that matches the longest part of the path).
+        """
+        if not path_components:
+            return self
+        first = path_components[0]
+        for child in self.children:
+            if child.name == first:
+                return child.find_best_match(path_components[1:])
+        return self
+
+
+class RuleEvaluator(object):
+    """
+    Evaluates which maintainer entry(ies) is active for a set of rules.
+    This is used by going step by step from the root directory to the
+    most specific directory/file, calling add_rules() for each step
+    on the way.
+    """
+
+    def __init__(self, other=None):
+        self._maint_entries_list = []
+        if other: # deep copy
+            for me in other._maint_entries_list:
+                self._maint_entries_list.append(list(me))
+
+    def add_rules(self, rules):
+        new_maint_entries = []
+        for rule in rules:
+            if rule.include:
+                new_maint_entries.append(rule.maintainer_entry)
+            else:
+                for maint_entries in self._maint_entries_list:
+                    maint_entries[:] = [me for me in maint_entries if not me is rule.maintainer_entry]
+        self._maint_entries_list.append(new_maint_entries)
+
+    def get_active_maintainer_entries(self):
+        for maint_entries in reversed(self._maint_entries_list):
+            if maint_entries:
+                return maint_entries
+        return []
+
+
+class VerifyResult(object):
+    def __init__(self):
+        self.no_maintainer = []
+        self.multiple_maintainers = []
+
+
+def find_matching_maintainer(node):
+    """
+    Finds the maintainer entry(ies) for a specific node.
+    """
+    nodes = []
+    while node:
+        nodes.insert(0, node)
+        node = node.parent
+
+    evaluator = RuleEvaluator()
+    for n in nodes:
+        evaluator.add_rules(n.rules)
+    return evaluator.get_active_maintainer_entries()
+
+
+def verify(node, path, files, evaluator, result):
+    """
+    Finds all files/directories that have either zero or several equally matching maintainer_entry's.
+
+    Searches recursively starting from the 'node' parameter, ignoring any files in the file system that
+    are not in the 'files' list.
+
+    Args:
+        node:      The RuleTreeNode where the search starts
+        path:      The file system path of 'node'
+        files:     A list of all applicable file paths, any files founds not in this list are ignored
+        evaluator: RuleEvaluator (already initialized with the rules of any parent nodes)
+        result:    VerifyResult output parameter
+    """
+
+    # This turned out to be quite a bit faster than using os.path.join()
+    def join(path, c):
+        if path == '/':
+            return path + c
+        else:
+            return path + '/' + c
+
+    # Update the evaluator with current node, and get the number of active maintainer entries
+    evaluator.add_rules(node.rules)
+    num_active_maintainer_entries = len(evaluator.get_active_maintainer_entries())
+
+    def check_add_path(path):
+        "Adds a path to a output list if necessary"
+        if num_active_maintainer_entries != 1:
+            if any(f.startswith(path) for f in files):
+                error_list = result.no_maintainer if num_active_maintainer_entries == 0 else result.multiple_maintainers
+                error_list.append(path)
+
+    if os.path.isdir(path):
+        children = os.listdir(path)
+        if children:
+            if node.children:
+                # Check all child rules that refers to existing files
+                for node_child in node.children:
+                    if node_child.name in children:
+                        verify(node_child, join(path, node_child.name), files, RuleEvaluator(evaluator), result)
+            # Check all existing files that does not have explicit rules
+            for child in children:
+                if not child in [c.name for c in node.children]:
+                    check_add_path(join(path, child))
+    else:
+        check_add_path(path)
 
 
 class Maintainers(object):
@@ -61,6 +231,17 @@ class Maintainers(object):
                         maintainerfile.append(line.strip().encode('utf-8'))
         self._read_maintainer_scopes(maintainerfile)
         self._verify_paths()
+        self._make_rule_tree()
+
+    def _make_rule_tree(self):
+        self._tree = RuleTreeNode('', None, [])
+        for maint in self.get_maintainer_list():
+            for pattern in maint['file-include-pattern']:
+                for path in glob.glob(pattern):
+                    self._tree.insert(Rule(path, maint, 'include'))
+            for pattern in maint['file-exclude-pattern']:
+                for path in glob.glob(pattern):
+                    self._tree.insert(Rule(path, maint, 'exclude'))
 
     def _verify_paths(self):
         is_ok = True
@@ -128,6 +309,14 @@ class Maintainers(object):
                 return entry
         return None
 
+    def verify_maintainers(self, files):
+        """
+        Verifies that each file is covered by exactly one subsystem
+        """
+        result = VerifyResult()
+        verify(self._tree, '/', files, RuleEvaluator(), result)
+        return result.no_maintainer, result.multiple_maintainers
+
     def find_matching_maintainers(self, filename):
         """
         Searches for any maintainer responsible for filename
@@ -148,35 +337,13 @@ class Maintainers(object):
         Raises:
             None
         """
-        matching_maintainers = []
-        for maintainer in self.get_maintainer_list():
-            do_exclude = False
-            # First check exclude pattern
-            for exclpattern in maintainer['file-exclude-pattern']:
-                if exclpattern[-1:] == '/':  # Handle this like a catch-all recursive directory rule
-                    if filename.startswith(exclpattern):
-                        do_exclude = True
-                        logger.debug('Excluding "%s" based on, rule=%s', maintainer['subsystem'], exclpattern)
-                else:
-                    if fnmatch(filename, exclpattern):
-                        do_exclude = True
-                        logger.debug('Excluding "%s" based on, rule=%s', maintainer['subsystem'], exclpattern)
 
-            # Then check include pattern
-            if do_exclude is False:
-                for inclpattern in maintainer['file-include-pattern']:
-                    if filename[1] == '/':  # Handle this as an absolute path
-                        if filename.endswith(inclpattern):
-                            logger.debug('Found match for "%s", rule=%s', maintainer['subsystem'], inclpattern)
-                            matching_maintainers.append(maintainer)
-                    elif inclpattern[-1:] == '/':  # Handle this like a catch-all recursive directory rule
-                        if inclpattern in filename:
-                            logger.debug('Found match for "%s", rule=%s', maintainer['subsystem'], inclpattern)
-                            matching_maintainers.append(maintainer)
-                    elif fnmatch(filename, inclpattern):
-                        logger.debug('Found match for "%s", rule=%s', maintainer['subsystem'], inclpattern)
-                        matching_maintainers.append(maintainer)
-        return matching_maintainers
+        if filename.startswith('/'):
+            filename = filename[1:]
+        path_components = filename.split('/')
+        node = self._tree.find_best_match(path_components)
+        mes = find_matching_maintainer(node)
+        return mes
 
     def _read_maintainer_scopes(self, text):
         # Really not happy with this parsing,

--- a/Analyze/Maintainers_SUITE.py
+++ b/Analyze/Maintainers_SUITE.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+'''
+Copyright (c) 2016, Tomas Nilsson  <tomas.w.nilsson@ericsson.com> for Ericsson AB
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+**************************    THIS LINE IS 120 CHARACTERS WIDE - DO *NOT* EXCEED 120 CHARACTERS!    *******************
+
+
+Short description:
+'''
+import Maintainers
+import os
+import shutil
+import tempfile
+import unittest
+
+def touch(path):
+    dir_name = os.path.dirname(path)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+    with open(path, 'w') as f:
+        pass
+
+class testMaintainers(unittest.TestCase):
+    def test_maintainers(self):
+        try:
+            tdir = tempfile.mkdtemp()
+
+            with open(tdir + '/MAINTAINERS', 'w') as f:
+                f.write("""
+[MAIN]
+F:  {0}/main
+[UTILS]
+F:  {0}/utils
+F:  {0}/main/utils
+X:  {0}/main/utils/exception.txt
+[THIRD]
+F:  {0}/main/utils/double.cpp
+[FOURTH]
+F:  {0}/main/utils/double.cpp
+""".format(tdir))
+
+            touch(tdir + '/main/main.cpp') # MAIN
+            touch(tdir + '/main/utils/main_utils.cpp') # UTILS (more specific than MAIN)
+            touch(tdir + '/unmaintained.cpp') # no maintainer
+            touch(tdir + '/ignored.cpp') # ignored (not included below)
+            touch(tdir + '/utils/utils.cpp') # UTILS
+            touch(tdir + '/main/utils/exception.txt') # MAIN (since excluded by UTIL)
+            touch(tdir + '/main/utils/double.cpp') # THIRD and FOURTH
+
+            m = Maintainers.Maintainers(tdir + '/MAINTAINERS')
+
+            no, multi = m.verify_maintainers([
+                    tdir + '/main/main.cpp',
+                    tdir + '/main/utils/main_utils.cpp',
+                    tdir + '/unmaintained.cpp',
+                    tdir + '/utils/utils.cpp',
+                    tdir + '/main/utils/exception.txt',
+                    tdir + '/main/utils/double.cpp',
+                    ])
+
+            self.assertEqual(no, [tdir + '/unmaintained.cpp'])
+            self.assertEqual(multi, [tdir + '/main/utils/double.cpp'])
+
+            self.assertEqual(m.find_matching_maintainers(tdir + '/main/main.cpp')[0]['subsystem'], 'MAIN')
+            self.assertEqual(m.find_matching_maintainers(tdir + '/main/utils/main_utils.cpp')[0]['subsystem'], 'UTILS')
+            self.assertEqual(m.find_matching_maintainers(tdir + '/utils/utils.cpp')[0]['subsystem'], 'UTILS')
+            self.assertEqual(m.find_matching_maintainers(tdir + '/main/utils/exception.txt')[0]['subsystem'], 'MAIN')
+            self.assertEqual([me['subsystem'] for me in m.find_matching_maintainers(tdir + '/main/utils/double.cpp')], ['THIRD', 'FOURTH'])
+
+        finally:
+            shutil.rmtree(tdir)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Analyze/Maintainers_SUITE.py
+++ b/Analyze/Maintainers_SUITE.py
@@ -43,47 +43,48 @@ class testMaintainers(unittest.TestCase):
         try:
             tdir = tempfile.mkdtemp()
 
-            with open(tdir + '/MAINTAINERS', 'w') as f:
-                f.write("""
-[MAIN]
-F:  {0}/main
-[UTILS]
-F:  {0}/utils
-F:  {0}/main/utils
-X:  {0}/main/utils/exception.txt
-[THIRD]
-F:  {0}/main/utils/double.cpp
-[FOURTH]
-F:  {0}/main/utils/double.cpp
-""".format(tdir))
+            mfile_contents = ""
+            mfile_contents += "[MAIN]\n"
+            mfile_contents += "F:  {0}\n".format(os.path.join(tdir, 'main'))
+            mfile_contents += "[UTILS]\n"
+            mfile_contents += "F:  {0}\n".format(os.path.join(tdir, 'utils'))
+            mfile_contents += "F:  {0}\n".format(os.path.join(tdir, 'main', 'utils'))
+            mfile_contents += "X:  {0}\n".format(os.path.join(tdir, 'main', 'utils', 'exception.txt'))
+            mfile_contents += "[THIRD]\n"
+            mfile_contents += "F:  {0}\n".format(os.path.join(tdir, 'main', 'utils', 'double.cpp'))
+            mfile_contents += "[FOURTH]\n"
+            mfile_contents += "F:  {0}\n".format(os.path.join(tdir, 'main', 'utils', 'double.cpp'))
+            with open(os.path.join(tdir, 'MAINTAINERS'), 'w') as f:
+                f.write(mfile_contents)
 
-            touch(tdir + '/main/main.cpp') # MAIN
-            touch(tdir + '/main/utils/main_utils.cpp') # UTILS (more specific than MAIN)
-            touch(tdir + '/unmaintained.cpp') # no maintainer
-            touch(tdir + '/ignored.cpp') # ignored (not included below)
-            touch(tdir + '/utils/utils.cpp') # UTILS
-            touch(tdir + '/main/utils/exception.txt') # MAIN (since excluded by UTIL)
-            touch(tdir + '/main/utils/double.cpp') # THIRD and FOURTH
+            touch(os.path.join(tdir, 'main', 'main.cpp')) # MAIN
+            touch(os.path.join(tdir, 'main', 'utils', 'main_utils.cpp')) # UTILS (more specific than MAIN)
+            touch(os.path.join(tdir, 'unmaintained.cpp')) # no maintainer
+            touch(os.path.join(tdir, 'ignored.cpp')) # ignored (not included below)
+            touch(os.path.join(tdir, 'utils', 'utils.cpp')) # UTILS
+            touch(os.path.join(tdir, 'main', 'utils', 'exception.txt')) # MAIN (since excluded by UTIL)
+            touch(os.path.join(tdir, 'main', 'utils', 'double.cpp')) # THIRD and FOURTH
 
-            m = Maintainers.Maintainers(tdir + '/MAINTAINERS')
+            m = Maintainers.Maintainers(os.path.join(tdir, 'MAINTAINERS'))
 
             no, multi = m.verify_maintainers([
-                    tdir + '/main/main.cpp',
-                    tdir + '/main/utils/main_utils.cpp',
-                    tdir + '/unmaintained.cpp',
-                    tdir + '/utils/utils.cpp',
-                    tdir + '/main/utils/exception.txt',
-                    tdir + '/main/utils/double.cpp',
+                    os.path.join(tdir, 'main', 'main.cpp'),
+                    os.path.join(tdir, 'main', 'utils', 'main_utils.cpp'),
+                    os.path.join(tdir, 'unmaintained.cpp'),
+                    os.path.join(tdir, 'utils', 'utils.cpp'),
+                    os.path.join(tdir, 'main', 'utils', 'exception.txt'),
+                    os.path.join(tdir, 'main', 'utils', 'double.cpp'),
                     ])
 
-            self.assertEqual(no, [tdir + '/unmaintained.cpp'])
-            self.assertEqual(multi, [tdir + '/main/utils/double.cpp'])
+            self.assertEqual(no, [os.path.join(tdir, 'unmaintained.cpp')])
+            self.assertEqual(multi, [os.path.join(tdir, 'main', 'utils', 'double.cpp')])
 
-            self.assertEqual(m.find_matching_maintainers(tdir + '/main/main.cpp')[0]['subsystem'], 'MAIN')
-            self.assertEqual(m.find_matching_maintainers(tdir + '/main/utils/main_utils.cpp')[0]['subsystem'], 'UTILS')
-            self.assertEqual(m.find_matching_maintainers(tdir + '/utils/utils.cpp')[0]['subsystem'], 'UTILS')
-            self.assertEqual(m.find_matching_maintainers(tdir + '/main/utils/exception.txt')[0]['subsystem'], 'MAIN')
-            self.assertEqual([me['subsystem'] for me in m.find_matching_maintainers(tdir + '/main/utils/double.cpp')], ['THIRD', 'FOURTH'])
+            self.assertEqual(m.find_matching_maintainers(os.path.join(tdir, 'main', 'main.cpp)'))[0]['subsystem'], 'MAIN')
+            self.assertEqual(m.find_matching_maintainers(os.path.join(tdir, 'main', 'utils', 'main_utils.cpp'))[0]['subsystem'], 'UTILS')
+            self.assertEqual(m.find_matching_maintainers(os.path.join(tdir, 'utils', 'utils.cpp'))[0]['subsystem'], 'UTILS')
+            self.assertEqual(m.find_matching_maintainers(os.path.join(tdir, 'main', 'utils', 'exception.txt'))[0]['subsystem'], 'MAIN')
+            self.assertEqual([me['subsystem'] for me in m.find_matching_maintainers(os.path.join(tdir, 'main', 'utils', 'double.cpp'))],
+                             ['THIRD', 'FOURTH'])
 
         finally:
             shutil.rmtree(tdir)


### PR DESCRIPTION
Add functionality that checks that all files are covered by
exactly one rule in the maintainers file. A new method, verify(),
is added to Maintainers, which will return a list of all files
that do not match this criteria.

In order to do this quickly, the Maintainers class will contain
a tree structure of all the rules in a maintainer file. This will
avoid having to check the entire list of rules for every file.